### PR TITLE
Update license attribute

### DIFF
--- a/package.json
+++ b/package.json
@@ -32,12 +32,7 @@
     "email": "roninliu@foxmail.com",
     "url": "https://github.com/roninliu"
   },
-  "license": [
-    {
-      "type": "MIT",
-      "url": "https://github.com/roninliu/gulp-jszip/blob/master/LICENSE"
-    }
-  ],
+  "license": "MIT",
   "bugs": {
     "url": "https://github.com/roninliu/gulp-jszip/issues"
   },


### PR DESCRIPTION
specifying the type and URL is deprecated:

https://docs.npmjs.com/files/package.json#license
